### PR TITLE
Export DeepNonNullable type for use in exported API

### DIFF
--- a/src/utilities/defaults.ts
+++ b/src/utilities/defaults.ts
@@ -38,9 +38,6 @@ export function getFinalOptions<T, Y extends T>(input: T | undefined, defaults: 
 	return recurse(input, defaults);
 }
 
-/**
- * @internal
- */
 export type DeepNonNullable<T> = {
 	[P in keyof T]-?: NonNullable<DeepNonNullable<T[P]>>;
 };


### PR DESCRIPTION
Fixes #3 

The current @internal tag is causing the compiler to omit the DeepNonNullable type in type definition files. This breaks the type definition files for exported types that use this type.

This change will cause the TypeScript compiler to include the `DeepNonNullable` type in type definition files, allowing exported members such as `ConsoleTransport` to include the type in their exported APIs.