### PR TITLE
Export PrefixGenerator type for use in exported API

### DIFF
--- a/src/generators/PrefixGenerator.ts
+++ b/src/generators/PrefixGenerator.ts
@@ -25,9 +25,6 @@ const DEFAULT_COLORS = {
 	critical: chalk.redBright
 };
 
-/**
- * @internal
- */
 export class PrefixGenerator {
 
 	protected options;


### PR DESCRIPTION
Fixes #5 

The current @internal documentation attribute is causing the TypeScript compiler to omit the PrefixGenerator type in generated type definition files. This breaks the type definition files for exported types that include this type in their exported APIs.

This commit fixes the issue by exporting the PrefixGenerator type definition.