### PR TITLE
Default transports to Trace minimum logging level

### DIFF
--- a/src/transports/Transport.ts
+++ b/src/transports/Transport.ts
@@ -8,7 +8,7 @@ export abstract class Transport<S extends EventEmitterSchema = {}> extends Event
 	/**
 	 * Specifies the minimum logging level that the transport will handle.
 	 */
-	public level = LogLevel.Information;
+	public level = LogLevel.Trace;
 
 	/**
 	 * A map of attached loggers and the internal listeners used to receive their output.


### PR DESCRIPTION
Fixes #7 

While the `Logger` instance is currently using the `Trace` minimum logging level, the `Transport` instance is currently implementing an undocumented behavior of defaulting to `Information`.

It seems more consistent and intuitive to default to `Trace`, thereby displaying all logs by default and allowing users to reduce scope as needed.